### PR TITLE
Support shopspring/decimal

### DIFF
--- a/equality.go
+++ b/equality.go
@@ -2,6 +2,7 @@
 package assert
 
 import (
+	"github.com/shopspring/decimal"
 	"time"
 )
 
@@ -71,5 +72,12 @@ func EqualStrings(reporter interface{}, want, got string) {
 func EqualTime(reporter interface{}, want, got time.Time) {
 	if !got.Equal(want) {
 		reportError(reporter, &failedTimeCompMsg{want, got})
+	}
+}
+
+// EqualDecimal - asserts that two decimals are the same
+func EqualDecimal(reporter interface{}, want, got decimal.Decimal) {
+	if !got.Equal(want) {
+		reportError(reporter, &failedDecimalCompMsg{want, got})
 	}
 }

--- a/equality_test.go
+++ b/equality_test.go
@@ -2,6 +2,7 @@ package assert_test
 
 import (
 	"errors"
+	"github.com/shopspring/decimal"
 	"testing"
 	"time"
 
@@ -79,4 +80,13 @@ func TestEqualTime(t *testing.T) {
 	assert.EqualTime(fakeT, t1, t2)
 
 	assert.IncludesString(t, "\nEquality assertion failed:\n\t want: 2018-02-22 12:30:00 +0000 UTC \n\t  got: 2018-02-22 12:35:00 +0000 UTC", fakeT.lastMessage())
+}
+
+func TestEqualDecimal(t *testing.T) {
+	d0 := decimal.Zero
+	d1 := decimal.NewFromFloat(1)
+
+	fakeT := newFakeT()
+	assert.EqualDecimal(fakeT, d0, d1)
+	assert.IncludesString(t, "\nEquality assertion failed:\n\t want: 0 \n\t  got: 1", fakeT.lastMessage())
 }

--- a/formatters.go
+++ b/formatters.go
@@ -3,6 +3,7 @@ package assert
 
 import (
 	"fmt"
+	"github.com/shopspring/decimal"
 	"time"
 )
 
@@ -42,4 +43,8 @@ func formatTime(in time.Time) string {
 
 func formatInterface(in interface{}) string {
 	return fmt.Sprintf("%#v", in)
+}
+
+func formatDecimal(in decimal.Decimal) string {
+	return in.String()
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/AMekss/assert
 
 go 1.17
+
+require github.com/shopspring/decimal v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
+github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/messages.go
+++ b/messages.go
@@ -3,6 +3,7 @@ package assert
 
 import (
 	"fmt"
+	"github.com/shopspring/decimal"
 	"time"
 )
 
@@ -22,6 +23,7 @@ type failedIntCompMsg struct{ want, got int }
 type failedFloatCompMsg struct{ want, got float64 }
 type failedStrCompMsg struct{ want, got string }
 type failedTimeCompMsg struct{ want, got time.Time }
+type failedDecimalCompMsg struct{ want, got decimal.Decimal }
 type failedStrIncludeMsg struct{ expectedPhrase, got string }
 type failedErrorIncludeMsg struct {
 	expectedPhrase string
@@ -67,6 +69,10 @@ func (msg *failedTimeCompMsg) String() string {
 
 func (msg *failedIsNilCompMsg) String() string {
 	return fmt.Sprintf(failedEqualityFormat, "Nil", formatInterface(msg.got))
+}
+
+func (msg *failedDecimalCompMsg) String() string {
+	return fmt.Sprintf(failedEqualityFormat, formatDecimal(msg.want), formatDecimal(msg.got))
 }
 
 // Inclusion


### PR DESCRIPTION
Not sure if you accept external dependencies but `shopspring.decimal` is quite common where float's precision is not sufficient.

https://github.com/shopspring/decimal

Feel free to reject it, I'll use my fork then :-) 